### PR TITLE
Tidy up display of tokens and fix issuer text

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -5,6 +5,8 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;
 import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.web3j.abi.datatypes.generated.Uint16;
@@ -494,6 +496,10 @@ public class Ticket extends Token implements Parcelable
         TextView cat = activity.findViewById(R.id.cattext);
         TextView details = activity.findViewById(R.id.ticket_details);
         TextView ticketTime = activity.findViewById(R.id.time);
+        ImageView ticketIcon = activity.findViewById(R.id.ticketicon);
+        ImageView catIcon = activity.findViewById(R.id.caticon);
+        LinearLayout ticketLayout = activity.findViewById(R.id.ticketlayout);
+        LinearLayout catLayout = activity.findViewById(R.id.catlayout);
 
         int numberOfTickets = range.tokenIds.size();
         if (numberOfTickets > 0)
@@ -509,15 +515,35 @@ public class Ticket extends Token implements Parcelable
             name.setText(nameStr);
             amount.setText(seatCount);
             venue.setText(venueStr);
-            ticketRange.setText(
-                    nonFungibleToken.getAttribute("countryA").text + "-" +
-                            nonFungibleToken.getAttribute("countryB").text
-            );
-            cat.setText("M" + nonFungibleToken.getAttribute("match").text);
+
+            String countryA = nonFungibleToken.getAttribute("countryA").text;
+            String countryB = nonFungibleToken.getAttribute("countryB").text;
+
+            if (countryA.charAt(0) == 0 && countryB.charAt(0) == 0)
+            {
+                ticketLayout.setVisibility(View.GONE);
+            }
+            else
+            {
+                ticketRange.setText(countryA + "-" + countryB);
+            }
+
+            String catTxt = nonFungibleToken.getAttribute("match").text;
+
+            if (catTxt.equals("0"))
+            {
+                catLayout.setVisibility(View.GONE);
+            }
+            else
+            {
+                cat.setText("M" + catTxt);
+            }
+
             details.setText(
                     nonFungibleToken.getAttribute("locality").name + ": " +
                             nonFungibleToken.getAttribute("locality").text
             );
+
             try
             {
                 String eventTime = nonFungibleToken.getAttribute("time").text;

--- a/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
@@ -108,6 +108,19 @@ public class AssetDefinitionService
         loadExternalContracts();
     }
 
+    public boolean hasDefinition(String contractAddress)
+    {
+        TokenDefinition d = getAssetDefinition(contractAddress.toLowerCase());
+        if (d != assetDefinition)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     /**
      * Get asset definition given contract address
      *
@@ -167,9 +180,10 @@ public class AssetDefinitionService
         //Note we check that the contract is actually specified in the XML - if we're just using the XML
         //as a default then we will just get default 'ethereum' issuer.
         TokenDefinition definition = getAssetDefinition(contractAddress);
-        if (definition != null && definition.getNetworkFromContract(contractAddress) == 1)
+
+        if (definition != null && definition.addresses.containsKey(contractAddress))
         {
-            return assetDefinition.getKeyName();
+            return definition.getKeyName();
         }
         else
         {

--- a/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
@@ -225,7 +225,8 @@ public class SendActivity extends BaseActivity {
         });
     }
 
-    private void copyAddress() {
+    private void copyAddress()
+    {
         ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText(KEY_ADDRESS, wallet.address);
         if (clipboard != null) {
@@ -262,7 +263,8 @@ public class SendActivity extends BaseActivity {
         }
     }
 
-    private void onBack() {
+    private void onBack()
+    {
         if (ethDetailLayout.getVisibility() == View.VISIBLE)
         {
             finish();
@@ -270,7 +272,8 @@ public class SendActivity extends BaseActivity {
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(Menu menu)
+    {
         getMenuInflater().inflate(R.menu.menu_qr, menu);
         return super.onCreateOptionsMenu(menu);
     }

--- a/app/src/main/res/layout/item_ticket.xml
+++ b/app/src/main/res/layout/item_ticket.xml
@@ -140,7 +140,7 @@
                     <LinearLayout
                         android:id="@+id/ticketlayout"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
+                        android:layout_height="35dp"
                         android:layout_gravity="center_vertical"
                         android:layout_weight="1"
                         android:orientation="horizontal">
@@ -167,7 +167,7 @@
                     <LinearLayout
                         android:id="@+id/catlayout"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
+                        android:layout_height="35dp"
                         android:layout_gravity="center_vertical"
                         android:layout_weight="1"
                         android:orientation="horizontal">


### PR DESCRIPTION
Small fix to how tokens are displayed in token view. This fixes spacing issues say for example you have something in the 'category' slot but nothing in 'ticket' slot then it'll expand category slot so the text isn't crunched.

Also gets issuer from the KeyName field in the associated XML file.