### PR TITLE
Fix backup node usage

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -296,6 +296,7 @@ public class Token implements Parcelable
     {
         String currentState = realmToken.getBalance();
         if (currentState == null) return true;
+        if (tokenInfo.name != null && realmToken.getName() == null) return true; //signal to update database if correct name has been fetched (node timeout etc)
         String currentBalance = getFullBalance();
         return !currentState.equals(currentBalance);
     }

--- a/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepository.java
@@ -66,6 +66,7 @@ public class EthereumNetworkRepository implements EthereumNetworkRepositoryType 
 	private final PreferenceRepositoryType preferences;
     private final TickerService tickerService;
     private NetworkInfo defaultNetwork;
+    private String currentActiveRPC;
     private final Set<OnNetworkChangeListener> onNetworkChangedListeners = new HashSet<>();
 
     public EthereumNetworkRepository(PreferenceRepositoryType preferenceRepository, TickerService tickerService) {
@@ -91,6 +92,25 @@ public class EthereumNetworkRepository implements EthereumNetworkRepositoryType 
 	@Override
 	public NetworkInfo getDefaultNetwork() {
 		return defaultNetwork;
+	}
+
+	@Override
+	public void setActiveRPC(String rpcURL)
+	{
+		currentActiveRPC = rpcURL;
+	}
+
+	@Override
+	public String getActiveRPC()
+	{
+		if (currentActiveRPC != null)
+		{
+			return currentActiveRPC;
+		}
+		else
+		{
+			return defaultNetwork.rpcServerUrl;
+		}
 	}
 
 	@Override

--- a/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepositoryType.java
@@ -9,6 +9,10 @@ public interface EthereumNetworkRepositoryType {
 
 	NetworkInfo getDefaultNetwork();
 
+	String getActiveRPC();
+
+	void setActiveRPC(String rpcURL);
+
 	void setDefaultNetworkInfo(NetworkInfo networkInfo);
 
 	NetworkInfo[] getAvailableNetworkList();

--- a/app/src/main/java/io/stormbird/wallet/repository/GasSettingsRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/GasSettingsRepository.java
@@ -16,8 +16,8 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.disposables.Disposable;
 
-public class GasSettingsRepository implements GasSettingsRepositoryType {
-
+public class GasSettingsRepository implements GasSettingsRepositoryType
+{
     private final EthereumNetworkRepositoryType networkRepository;
     private BigInteger cachedGasPrice;
     private Disposable gasSettingsDisposable;
@@ -36,7 +36,7 @@ public class GasSettingsRepository implements GasSettingsRepositoryType {
 
     private void fetchGasSettings() {
 
-        final Web3j web3j = Web3jFactory.build(new HttpService(networkRepository.getDefaultNetwork().rpcServerUrl));
+        final Web3j web3j = Web3jFactory.build(new HttpService(networkRepository.getActiveRPC()));
 
         try {
             EthGasPrice price = web3j

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -104,6 +104,7 @@ public class TokenRepository implements TokenRepositoryType {
         network = defaultNetwork;
         org.web3j.protocol.http.HttpService publicNodeService = new org.web3j.protocol.http.HttpService(defaultNetwork.rpcServerUrl);
         web3j = Web3jFactory.build(publicNodeService);
+        ethereumNetworkRepository.setActiveRPC(defaultNetwork.rpcServerUrl);
 
         //test main node, if it's not working then use backup Infura node. If it's not working then we can't listen on the pool
         Disposable d = getWorkHash()
@@ -131,6 +132,7 @@ public class TokenRepository implements TokenRepositoryType {
     {
         org.web3j.protocol.http.HttpService publicNodeService = new org.web3j.protocol.http.HttpService(network.backupNodeUrl);
         web3j = Web3jFactory.build(publicNodeService);
+        ethereumNetworkRepository.setActiveRPC(network.backupNodeUrl);
     }
 
     private Single<BigInteger> getWorkHash()

--- a/app/src/main/java/io/stormbird/wallet/repository/TokensRealmSource.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokensRealmSource.java
@@ -421,6 +421,12 @@ public class TokensRealmSource implements TokenLocalSource {
                 TransactionsRealmCache.addRealm();
                 realm.beginTransaction();
                 token.setRealmBalance(realmToken);
+                if (token.tokenInfo.name != null)
+                {
+                    realmToken.setName(token.tokenInfo.name);
+                    realmToken.setSymbol(token.tokenInfo.symbol);
+                    realmToken.setDecimals(token.tokenInfo.decimals);
+                }
                 realmToken.setNullCheckCount(0);
                 realm.commitTransaction();
                 TransactionsRealmCache.subRealm();

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
@@ -145,7 +145,7 @@ public class TransactionRepository implements TransactionRepositoryType {
 
 	@Override
 	public Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password) {
-		final Web3j web3j = Web3jFactory.build(new HttpService(networkRepository.getDefaultNetwork().rpcServerUrl));
+		final Web3j web3j = Web3jFactory.build(new HttpService(networkRepository.getActiveRPC()));
 
 		return Single.fromCallable(() -> {
 			EthGetTransactionCount ethGetTransactionCount = web3j

--- a/app/src/main/java/io/stormbird/wallet/repository/WalletRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/WalletRepository.java
@@ -107,7 +107,7 @@ public class WalletRepository implements WalletRepositoryType
 			//return BigDecimal.valueOf(15.995).movePointRight(18);
 			try {
 				return new BigDecimal(Web3jFactory
-						.build(new org.web3j.protocol.http.HttpService(networkRepository.getDefaultNetwork().rpcServerUrl))
+						.build(new org.web3j.protocol.http.HttpService(networkRepository.getActiveRPC()))
 						.ethGetBalance(wallet.address, DefaultBlockParameterName.LATEST)
 						.send()
 						.getBalance());


### PR DESCRIPTION
Recently the prime Ropsten node went down and the app switched to the backup node correctly.

However it was noticed that values weren't updated correctly using the backup node as there are places in the source where RPC node calls are made outside of the main node operations.

With nodes going down or or having high network traffic sometimes null values are returned. The app needs to be able to update these values, not just stick with the first null value received.