### PR TITLE
Fix ethereum nonce update

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -61,21 +61,29 @@ public class Ticket extends Token implements Parcelable
 
     private Ticket(Parcel in) {
         super(in);
-        Object[] readObjArray = in.readArray(Object.class.getClassLoader());
-        Object[] readBurnArray = in.readArray(Object.class.getClassLoader());
         balanceArray = new ArrayList<>();
         burnIndices = new ArrayList<Integer>();
-        for (Object o : readObjArray)
+        int objSize = in.readInt();
+        int burnSize = in.readInt();
+        if (objSize > 0)
         {
-            BigInteger val = (BigInteger)o;
-            balanceArray.add(val);
+            Object[] readObjArray = in.readArray(Object.class.getClassLoader());
+            for (Object o : readObjArray)
+            {
+                BigInteger val = (BigInteger)o;
+                balanceArray.add(val);
+            }
         }
 
-        //check to see if burn notice is needed
-        for (Object o : readBurnArray)
+        if (burnSize > 0)
         {
-            Integer val = (Integer)o;
-            burnIndices.add(val);
+            Object[] readBurnArray = in.readArray(Object.class.getClassLoader());
+            //check to see if burn notice is needed
+            for (Object o : readBurnArray)
+            {
+                Integer val = (Integer)o;
+                burnIndices.add(val);
+            }
         }
     }
 
@@ -110,8 +118,10 @@ public class Ticket extends Token implements Parcelable
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         super.writeToParcel(dest, flags);
-        dest.writeArray(balanceArray.toArray());
-        dest.writeArray(burnIndices.toArray());
+        dest.writeInt(balanceArray.size());
+        dest.writeInt(burnIndices.size());
+        if (balanceArray.size() > 0) dest.writeArray(balanceArray.toArray());
+        if (burnIndices.size() > 0) dest.writeArray(burnIndices.toArray());
     }
 
     /**

--- a/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepository.java
@@ -71,7 +71,7 @@ public class EthereumNetworkRepository implements EthereumNetworkRepositoryType 
 	private final PreferenceRepositoryType preferences;
     private final TickerService tickerService;
     private NetworkInfo defaultNetwork;
-    private BigInteger currentNonce = BigInteger.ZERO;
+    private String currentActiveRPC;
     private final Set<OnNetworkChangeListener> onNetworkChangedListeners = new HashSet<>();
 
     public EthereumNetworkRepository(PreferenceRepositoryType preferenceRepository, TickerService tickerService) {
@@ -106,22 +106,10 @@ public class EthereumNetworkRepository implements EthereumNetworkRepositoryType 
 	{
 		return Single.fromCallable(() -> {
 			EthGetTransactionCount ethGetTransactionCount = web3j
-					.ethGetTransactionCount(walletAddress, DefaultBlockParameterName.LATEST)
+					.ethGetTransactionCount(walletAddress, DefaultBlockParameterName.PENDING)
 					.send();
-			BigInteger receivedNonce = ethGetTransactionCount.getTransactionCount();
-			if (receivedNonce.compareTo(currentNonce) <= 0) //less than or equal to
-			{
-				receivedNonce = currentNonce.add(BigInteger.ONE);
-			}
-			currentNonce = receivedNonce;
-			return receivedNonce;
+			return ethGetTransactionCount.getTransactionCount();
 		});
-	}
-
-	@Override
-	public void resetCurrentNonce()
-	{
-		currentNonce = BigInteger.ZERO;
 	}
 
 	@Override

--- a/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepositoryType.java
@@ -1,5 +1,9 @@
 package io.stormbird.wallet.repository;
 
+import org.web3j.protocol.Web3j;
+
+import java.math.BigInteger;
+
 import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Ticker;
 
@@ -8,6 +12,9 @@ import io.reactivex.Single;
 public interface EthereumNetworkRepositoryType {
 
 	NetworkInfo getDefaultNetwork();
+
+	Single<BigInteger> getLastTransactionNonce(Web3j web3j, String walletAddress);
+	void resetCurrentNonce();
 
 	void setDefaultNetworkInfo(NetworkInfo networkInfo);
 

--- a/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepositoryType.java
@@ -14,7 +14,6 @@ public interface EthereumNetworkRepositoryType {
 	NetworkInfo getDefaultNetwork();
 
 	Single<BigInteger> getLastTransactionNonce(Web3j web3j, String walletAddress);
-	void resetCurrentNonce();
 
 	void setDefaultNetworkInfo(NetworkInfo networkInfo);
 

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -104,6 +104,7 @@ public class TokenRepository implements TokenRepositoryType {
         network = defaultNetwork;
         org.web3j.protocol.http.HttpService publicNodeService = new org.web3j.protocol.http.HttpService(defaultNetwork.rpcServerUrl);
         web3j = Web3jFactory.build(publicNodeService);
+        ethereumNetworkRepository.resetCurrentNonce();
 
         //test main node, if it's not working then use backup Infura node. If it's not working then we can't listen on the pool
         Disposable d = getWorkHash()

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -104,7 +104,6 @@ public class TokenRepository implements TokenRepositoryType {
         network = defaultNetwork;
         org.web3j.protocol.http.HttpService publicNodeService = new org.web3j.protocol.http.HttpService(defaultNetwork.rpcServerUrl);
         web3j = Web3jFactory.build(publicNodeService);
-        ethereumNetworkRepository.resetCurrentNonce();
 
         //test main node, if it's not working then use backup Infura node. If it's not working then we can't listen on the pool
         Disposable d = getWorkHash()

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
@@ -195,7 +195,8 @@ public class TransactionRepository implements TransactionRepositoryType {
 				.observeOn(Schedulers.io());
     }
 
-	private Single<Transaction[]> fetchAllFromNetwork(NetworkInfo networkInfo, Wallet wallet) {
+	private Single<Transaction[]> fetchAllFromNetwork(NetworkInfo networkInfo, Wallet wallet)
+	{
 		return Single.fromObservable(blockExplorerClient.fetchLastTransactions(networkInfo, wallet, 0))
 				.observeOn(Schedulers.io());
 	}

--- a/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
@@ -19,6 +19,7 @@ import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetDialog;
+import android.support.multidex.MultiDex;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -79,6 +80,12 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
 
     public static final int RC_DOWNLOAD_EXTERNAL_WRITE_PERM = 222;
     public static final int RC_ASSET_EXTERNAL_WRITE_PERM = 223;
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+        MultiDex.install(this);
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/io/stormbird/wallet/ui/SplashActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SplashActivity.java
@@ -1,9 +1,15 @@
 package io.stormbird.wallet.ui;
 
 import android.arch.lifecycle.ViewModelProviders;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.multidex.MultiDex;
 
 import javax.inject.Inject;
 
@@ -24,6 +30,12 @@ public class SplashActivity extends BaseActivity {
     SplashViewModel splashViewModel;
 
     private String importData;
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+        MultiDex.install(this);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,7 +64,9 @@ public class SplashActivity extends BaseActivity {
         splashViewModel.createWallet().observe(this, this::onWalletCreate);
         splashViewModel.setLocale(getApplicationContext());
 
-        splashViewModel.checkVersionUpdate(getBaseContext());
+        long getAppUpdateTime = getAppLastUpdateTime();
+
+        splashViewModel.checkVersionUpdate(getBaseContext(), getAppUpdateTime);
         splashViewModel.startOverridesChain();
     }
 
@@ -62,6 +76,29 @@ public class SplashActivity extends BaseActivity {
         Wallet[] wallets = new Wallet[1];
         wallets[0] = wallet;
         onWallets(wallets);
+    }
+
+    private long getAppLastUpdateTime()
+    {
+        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
+        long currentInstallDate = pref.getLong("install_time", 0);
+
+        if (currentInstallDate == 0)
+        {
+            pref.edit().putLong("install_time", System.currentTimeMillis()).apply();
+        }
+
+        try
+        {
+            PackageInfo info =  getPackageManager().getPackageInfo(getPackageName(), PackageManager.GET_META_DATA);
+            if (info.lastUpdateTime > currentInstallDate) currentInstallDate = info.lastUpdateTime;
+        }
+        catch (PackageManager.NameNotFoundException e)
+        {
+            e.printStackTrace();
+        }
+
+        return currentInstallDate;
     }
 
     private void onWallets(Wallet[] wallets) {

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/SplashViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/SplashViewModel.java
@@ -6,23 +6,18 @@ import android.arch.lifecycle.ViewModel;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.preference.PreferenceManager;
 
-import java.io.File;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
-import io.stormbird.wallet.BuildConfig;
 import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.TokenInfo;
@@ -189,26 +184,22 @@ public class SplashViewModel extends ViewModel {
                 }, this::onError);
     }
 
-    public void checkVersionUpdate(Context ctx)
+    public void checkVersionUpdate(Context ctx, long updateTime)
     {
         if (!isPlayStoreInstalled(ctx))
         {
             //check the current install version string against the current version on the alphawallet page
             //current version number as string
             SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(ctx);
-            //pref.edit().putLong("install_time", 1000).apply(); //for testing, you can reset the clock to a time that's before the release on the website
-
-            //get the current install date
-            long currentInstallDate = pref.getLong("install_time", 0);
             int asks = pref.getInt("update_asks", 0);
-            if (currentInstallDate == 0 || asks == 2) // if user cancels update twice stop asking them until the next release
+            if (updateTime == 0 || asks == 2) // if user cancels update twice stop asking them until the next release
             {
                 pref.edit().putInt("update_asks", 0).apply();
                 pref.edit().putLong("install_time", System.currentTimeMillis()).apply();
             }
             else
             {
-                checkWebsiteAPKFileData(currentInstallDate, ctx);
+                checkWebsiteAPKFileData(updateTime, ctx);
             }
         }
     }


### PR DESCRIPTION
This patch's main focus was to fix the ethereum nonce issue reported where several ERC20 transactions processed quickly will fail. This is because 'getTransactionCount' will return the transactions currently written to blockchain and doesn't account for pending transactions.

The real solution is to read the transaction pool and take into account any transaction sitting in the pool and generate the nonce accordingly. However caching the last used value and taking that into account provides a fine interim solution.

The PR also fixes the Multidex issue encountered by one person at a meetup - it turns out you need to instantiate the multidex library explicitly for Android in some instances.