### PR TITLE
Add token validity check

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -297,6 +297,7 @@ public class Token implements Parcelable
         String currentState = realmToken.getBalance();
         if (currentState == null) return true;
         if (tokenInfo.name != null && realmToken.getName() == null) return true; //signal to update database if correct name has been fetched (node timeout etc)
+        if (tokenInfo.isStormbird != realmToken.isStormbird()) return true;
         String currentBalance = getFullBalance();
         return !currentState.equals(currentBalance);
     }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokensRealmSource.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokensRealmSource.java
@@ -426,6 +426,7 @@ public class TokensRealmSource implements TokenLocalSource {
                     realmToken.setName(token.tokenInfo.name);
                     realmToken.setSymbol(token.tokenInfo.symbol);
                     realmToken.setDecimals(token.tokenInfo.decimals);
+                    realmToken.setStormbird(token.tokenInfo.isStormbird);
                 }
                 realmToken.setNullCheckCount(0);
                 realm.commitTransaction();


### PR DESCRIPTION
Checks if we received an array balance from a token. If so, switch it to ERC875 interpretation.

After extensive testing, blanking database and restoring from blockchain it was noticed sometimes an ERC875 token would be picked up as ERC20.

The reason for this is timeouts in the 'isStormbird' function.

When the app receives the balance - which is the same function for ERC20 and ERC875 it can with zero ambiguity (*) be determined if the token has an array balance or the expected BigInteger balance for an ERC20.

This mod corrects the received type on interpreting the balance type.



(*) There is zero ambiguity for checking an array balance - a single BigInteger vs a BigInteger array specification (0x20) followed by BigInteger array length followed by the array values.