### PR TITLE
Mark terminated contracts

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/di/RepositoriesModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/RepositoriesModule.java
@@ -32,6 +32,7 @@ import io.stormbird.wallet.service.MarketQueueService;
 import io.stormbird.wallet.service.RealmManager;
 import io.stormbird.wallet.service.TickerService;
 import io.stormbird.wallet.service.TokenExplorerClientType;
+import io.stormbird.wallet.service.TokensService;
 import io.stormbird.wallet.service.TransactionsNetworkClient;
 import io.stormbird.wallet.service.TransactionsNetworkClientType;
 
@@ -148,6 +149,12 @@ public class RepositoriesModule {
 	@Provides
 	GasSettingsRepositoryType provideGasSettingsRepository(EthereumNetworkRepositoryType ethereumNetworkRepository) {
 		return new GasSettingsRepository(ethereumNetworkRepository);
+	}
+
+	@Singleton
+	@Provides
+	TokensService provideTokensService( ) {
+		return new TokensService( );
 	}
 
 	@Singleton

--- a/app/src/main/java/io/stormbird/wallet/di/TransactionsModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/TransactionsModule.java
@@ -14,6 +14,7 @@ import io.stormbird.wallet.router.ExternalBrowserRouter;
 import io.stormbird.wallet.router.HomeRouter;
 import io.stormbird.wallet.router.TransactionDetailRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
+import io.stormbird.wallet.service.TokensService;
 import io.stormbird.wallet.viewmodel.TransactionsViewModelFactory;
 
 import dagger.Module;
@@ -32,7 +33,8 @@ class TransactionsModule {
             TransactionDetailRouter transactionDetailRouter,
             ExternalBrowserRouter externalBrowserRouter,
             HomeRouter homeRouter,
-            AssetDefinitionService assetDefinitionService) {
+            AssetDefinitionService assetDefinitionService,
+            TokensService tokensService) {
         return new TransactionsViewModelFactory(
                 findDefaultNetworkInteract,
                 findDefaultWalletInteract,
@@ -43,7 +45,8 @@ class TransactionsModule {
                 transactionDetailRouter,
                 externalBrowserRouter,
                 homeRouter,
-                assetDefinitionService);
+                assetDefinitionService,
+                tokensService);
     }
 
     @Provides

--- a/app/src/main/java/io/stormbird/wallet/di/WalletModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/WalletModule.java
@@ -15,6 +15,7 @@ import io.stormbird.wallet.router.AssetDisplayRouter;
 import io.stormbird.wallet.router.ChangeTokenCollectionRouter;
 import io.stormbird.wallet.router.SendTokenRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
+import io.stormbird.wallet.service.TokensService;
 import io.stormbird.wallet.viewmodel.WalletViewModelFactory;
 
 import dagger.Module;
@@ -34,7 +35,8 @@ public class WalletModule {
             GetDefaultWalletBalance getDefaultWalletBalance,
             AddTokenInteract addTokenInteract,
             SetupTokensInteract setupTokensInteract,
-            AssetDefinitionService assetDefinitionService) {
+            AssetDefinitionService assetDefinitionService,
+            TokensService tokensService) {
         return new WalletViewModelFactory(
                 fetchTokensInteract,
                 addTokenRouter,
@@ -46,7 +48,8 @@ public class WalletModule {
                 getDefaultWalletBalance,
                 addTokenInteract,
                 setupTokensInteract,
-                assetDefinitionService);
+                assetDefinitionService,
+                tokensService);
     }
 
     @Provides

--- a/app/src/main/java/io/stormbird/wallet/entity/ERC875ContractTransaction.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/ERC875ContractTransaction.java
@@ -19,7 +19,7 @@ import static io.stormbird.wallet.entity.TransactionOperation.ERC875_CONTRACT_TY
 public class ERC875ContractTransaction extends TransactionContract implements Parcelable {
     public String balance;
     public String symbol;
-    public int operation;
+    public TransactionType operation;
     public String otherParty;
     public List<Integer> indices;
     public int type;
@@ -36,7 +36,7 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
         name = "";
         balance = "";
         symbol = "";
-        operation = 0;
+        operation = TransactionType.UNKNOWN;
         otherParty = "";
         //operationDisplayName = "";
         indices = null;
@@ -67,7 +67,9 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
         name = in.readString();
         balance = in.readString();
         symbol = in.readString();
-        operation = in.readInt();
+        int typeCode = in.readInt();
+        if (typeCode >= TransactionType.ILLEGAL_VALUE.ordinal()) typeCode = TransactionType.ILLEGAL_VALUE.ordinal();
+        operation = TransactionType.values()[typeCode];
         type = in.readInt();
         otherParty = in.readString();
         //operationDisplayName = in.readString();
@@ -110,7 +112,8 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
         parcel.writeString(name);
         parcel.writeString(balance);
         parcel.writeString(symbol);
-        parcel.writeInt(operation);
+        int opWrite = operation.ordinal();
+        parcel.writeInt(opWrite);
         parcel.writeInt(type);
         parcel.writeString(otherParty);
 
@@ -162,13 +165,13 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
             if (otherParty.equals(walletAddr))
             {
                 //transfered out of our wallet via magic link
-                operation = R.string.ticket_magiclink_transfer;
+                operation = TransactionType.MAGICLINK_TRANSFER;// R.string.ticket_magiclink_transfer;
                 type = -1;
             }
             else
             {
                 //received ticket from a magic link
-                operation = R.string.ticket_magiclink_pickup;
+                operation = TransactionType.MAGICLINK_PICKUP;// R.string.ticket_magiclink_pickup;
                 type = 1;
             }
         }
@@ -177,13 +180,13 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
             if (otherParty.equals(walletAddr))
             {
                 //we received ether from magiclink sale
-                operation = R.string.ticket_magiclink_sale;
+                operation = TransactionType.MAGICLINK_SALE;// R.string.ticket_magiclink_sale;
                 type = -1;
             }
             else
             {
                 //we purchased a ticket from a magiclink
-                operation = R.string.ticket_magiclink_purchase;
+                operation = TransactionType.MAGICLINK_PURCHASE;// R.string.ticket_magiclink_purchase;
                 type = 1;
             }
         }
@@ -192,11 +195,11 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
     @Override
     public void interpretTransferFrom(String walletAddr, TransactionInput data)
     {
-        operation = R.string.ticket_redeem;
+        operation = TransactionType.REDEEM;//R.string.ticket_redeem;
         if (!data.containsAddress(walletAddr))
         {
             //this must be an admin redeem
-            operation = R.string.ticket_admin_redeem;
+            operation = TransactionType.ADMIN_REDEEM;// R.string.ticket_admin_redeem;
         }
         //one of our tickets was burned
         type = -1; //redeem
@@ -209,12 +212,12 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
         //if addresses contains our address then it must be a recieve
         if (data.containsAddress(walletAddr))
         {
-            operation = R.string.ticket_receive_from;
+            operation = TransactionType.RECEIVE_FROM;// R.string.ticket_receive_from;
             type = 1; //buy/receive
         }
         else
         {
-            operation = R.string.ticket_transfer_to;
+            operation = TransactionType.TRANSFER_TO;// R.string.ticket_transfer_to;
             type = -1; //sell
             otherParty = data.getFirstAddress();
         }
@@ -227,7 +230,7 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
     }
 
     @Override
-    public void setOperation(int operation)
+    public void setOperation(TransactionType operation)
     {
         super.setOperation(operation);
         this.operation = operation;
@@ -245,14 +248,14 @@ public class ERC875ContractTransaction extends TransactionContract implements Pa
         if (data.containsAddress(walletAddr))
         {
             //we received a ticket from magiclink with transfer paid by server
-            operation = R.string.ticket_pass_from;
+            operation = TransactionType.PASS_FROM;// R.string.ticket_pass_from;
             type = 1;
         }
         else
         {
             //we had a ticket transferred out of our wallet paid for by server.
             //This will not show up unless we ecrecover the address.
-            operation = R.string.ticket_pass_to;
+            operation = TransactionType.PASS_TO;//R.string.ticket_pass_to;
             type = -1;
         }
     }

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -23,12 +23,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.stormbird.wallet.C.ETH_SYMBOL;
+import static io.stormbird.wallet.interact.SetupTokensInteract.EXPIRED_CONTRACT;
+import static io.stormbird.wallet.interact.SetupTokensInteract.UNKNOWN_CONTRACT;
 
 public class Token implements Parcelable
 {
     public final TokenInfo tokenInfo;
     public BigDecimal balance;
-    public final long updateBlancaTime;
+    public long updateBlancaTime;
     public boolean balanceIsLive = false;
     public boolean isERC20 = false; //TODO: when we see ERC20 functions in transaction decoder switch this on
     private boolean isEth = false;
@@ -102,12 +104,20 @@ public class Token implements Parcelable
         }
     }
 
+    public void setIsTerminated(RealmToken realmToken)
+    {
+        realmToken.setUpdatedTime(-1);
+        updateBlancaTime = -1;
+    }
+    public boolean isTerminated() { return (updateBlancaTime == -1); }
+
     public String getAddress() {
         return tokenInfo.address;
     }
     public String getFullName()
     {
-        if (tokenInfo.name == null) return null;
+        if (isTerminated()) return EXPIRED_CONTRACT;
+        if (isBad()) return UNKNOWN_CONTRACT;
         return tokenInfo.name + (tokenInfo.symbol != null && tokenInfo.symbol.length() > 0 ? "(" + tokenInfo.symbol.toUpperCase() + ")" : "");
     }
 

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionContract.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionContract.java
@@ -88,9 +88,9 @@ public class TransactionContract implements Parcelable {
 
     }
 
-    public void setOperation(int operation)
+    public void setOperation(TransactionType operation)
     {
-        if (operation == R.string.ticket_invalid_op)
+        if (operation == TransactionType.INVALID_OPERATION)
         {
             badTransaction = true;
         }

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionDecoder.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionDecoder.java
@@ -29,6 +29,8 @@ public class TransactionDecoder
 {
     TransactionInput thisData;
 
+    private static List<String> endContractSignatures = new ArrayList<>();
+
     private int parseIndex;
     private Map<String, FunctionData> functionList;
 
@@ -201,7 +203,6 @@ public class TransactionDecoder
         }
     }
 
-
     private void setupKnownFunctions()
     {
         functionList = new HashMap<>();
@@ -217,6 +218,8 @@ public class TransactionDecoder
         addContractCreation();
     }
 
+    /* NB: this doesn't always work. Instead we read the construction event from Etherscan
+     */
     private void addContractCreation()
     {
         FunctionData data = new FunctionData();
@@ -237,18 +240,22 @@ public class TransactionDecoder
             "approve(address,uint256)",
             "loadNewTickets(bytes32[])",
             "passTo(uint256,uint16[],uint8,bytes32,bytes32,address)",
-            "endContract()"
+            "endContract()",
+            "selfdestruct()",
+            "kill()"
             };
 
     static final boolean[] HAS_SIG = {
-            false,
-            false,
+            false,  //transferFrom
+            false,  //transfer
             true,
             false,
             false,
             false,
-            false,
-            true,
+            false, //loadNewTickets
+            true,  //passTo
+            false, //endContract
+            false,  //selfdestruct()
             false
     };
 
@@ -257,15 +264,17 @@ public class TransactionDecoder
     static final int CREATION = 3;
 
     static final int[] CONTRACT_TYPE = {
+            ERC875,  //transferFrom
             ERC875,
             ERC875,
-            ERC875,
+            ERC20,   //transferFrom
             ERC20,
             ERC20,
-            ERC20,
             ERC875,
             ERC875,
-            CREATION
+            CREATION, //endContract
+            CREATION, //selfdestruct
+            CREATION  //kill
     };
 
     private FunctionData getArgs(String methodSig)
@@ -330,10 +339,37 @@ public class TransactionDecoder
         return indices;
     }
 
-    private String buildMethodId(String methodSignature) {
+    public static String buildMethodId(String methodSignature) {
         byte[] input = methodSignature.getBytes();
         byte[] hash = Hash.sha3(input);
         return Numeric.toHexString(hash).substring(0, 10);
+    }
+
+    public static boolean isEndContract(String input)
+    {
+        if (input == null || input.length() != 10)
+        {
+            return false;
+        }
+
+        if (endContractSignatures.size() == 0)
+        {
+            buildEndContractSigs();
+        }
+
+        for (String sig : endContractSignatures)
+        {
+            if (input.equals(sig)) return true;
+        }
+
+        return false;
+    }
+
+    private static void buildEndContractSigs()
+    {
+        endContractSignatures.add(buildMethodId("endContract()"));
+        endContractSignatures.add(buildMethodId("selfdestruct()"));
+        endContractSignatures.add(buildMethodId("kill()"));
     }
 }
 

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionDecoder.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionDecoder.java
@@ -339,7 +339,7 @@ public class TransactionDecoder
         return indices;
     }
 
-    public static String buildMethodId(String methodSignature) {
+    private static String buildMethodId(String methodSignature) {
         byte[] input = methodSignature.getBytes();
         byte[] hash = Hash.sha3(input);
         return Numeric.toHexString(hash).substring(0, 10);

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionLookup.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionLookup.java
@@ -1,0 +1,39 @@
+package io.stormbird.wallet.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.stormbird.wallet.R;
+
+public class TransactionLookup
+{
+    private static Map<TransactionType, Integer> typeMapping = new HashMap<>();
+
+    public static int typeToName(TransactionType type)
+    {
+        setupTypes();
+        return typeMapping.get(type);
+    }
+
+    private static void setupTypes()
+    {
+        if (typeMapping.size() == 0)
+        {
+            typeMapping.put(TransactionType.UNKNOWN, R.string.ticket_invalid_op);
+            typeMapping.put(TransactionType.LOAD_NEW_TOKENS, R.string.ticket_load_new_tickets);
+            typeMapping.put(TransactionType.MAGICLINK_TRANSFER, R.string.ticket_magiclink_transfer);
+            typeMapping.put(TransactionType.MAGICLINK_PICKUP, R.string.ticket_magiclink_pickup);
+            typeMapping.put(TransactionType.MAGICLINK_SALE, R.string.ticket_magiclink_sale);
+            typeMapping.put(TransactionType.MAGICLINK_PURCHASE, R.string.ticket_magiclink_purchase);
+            typeMapping.put(TransactionType.PASS_TO, R.string.ticket_pass_to);
+            typeMapping.put(TransactionType.PASS_FROM, R.string.ticket_pass_from);
+            typeMapping.put(TransactionType.TRANSFER_TO, R.string.ticket_transfer_to);
+            typeMapping.put(TransactionType.RECEIVE_FROM, R.string.ticket_receive_from);
+            typeMapping.put(TransactionType.REDEEM, R.string.ticket_redeem);
+            typeMapping.put(TransactionType.ADMIN_REDEEM, R.string.ticket_admin_redeem);
+            typeMapping.put(TransactionType.CONSTRUCTOR, R.string.ticket_contract_constructor);
+            typeMapping.put(TransactionType.TERMINATE_CONTRACT, R.string.ticket_terminate_contract);
+            typeMapping.put(TransactionType.UNKNOWN_FUNCTION, R.string.ticket_invalid_op);
+        }
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionType.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionType.java
@@ -1,0 +1,22 @@
+package io.stormbird.wallet.entity;
+
+public enum TransactionType
+{
+    UNKNOWN,
+    LOAD_NEW_TOKENS,
+    MAGICLINK_TRANSFER,
+    MAGICLINK_PICKUP,
+    MAGICLINK_SALE,
+    MAGICLINK_PURCHASE,
+    PASS_TO,
+    PASS_FROM,
+    TRANSFER_TO,
+    RECEIVE_FROM,
+    REDEEM,
+    ADMIN_REDEEM,
+    CONSTRUCTOR,
+    TERMINATE_CONTRACT,
+    UNKNOWN_FUNCTION,
+    INVALID_OPERATION,
+    ILLEGAL_VALUE
+};

--- a/app/src/main/java/io/stormbird/wallet/interact/AddTokenInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/AddTokenInteract.java
@@ -1,5 +1,6 @@
 package io.stormbird.wallet.interact;
 
+import io.reactivex.Single;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.TokenInfo;
 import io.stormbird.wallet.entity.Wallet;
@@ -27,6 +28,13 @@ public class AddTokenInteract {
                 .flatMap(wallet -> tokenRepository
                         .addToken(wallet, tokenInfo))
                 .toObservable();
+    }
+
+    public Single<Token> addS(TokenInfo tokenInfo) {
+        return walletRepository
+                    .getDefaultWallet()
+                    .flatMap(wallet -> tokenRepository
+                            .addToken(wallet, tokenInfo));
     }
 
     public Observable<Token> add(TokenInfo tokenInfo, Wallet wallet) {

--- a/app/src/main/java/io/stormbird/wallet/interact/AddTokenInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/AddTokenInteract.java
@@ -30,6 +30,11 @@ public class AddTokenInteract {
                 .toObservable();
     }
 
+    /**
+     * Add Token to respository process which is a single not an observable
+     * @param tokenInfo
+     * @return
+     */
     public Single<Token> addS(TokenInfo tokenInfo) {
         return walletRepository
                     .getDefaultWallet()

--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTokensInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTokensInteract.java
@@ -6,6 +6,7 @@ import io.stormbird.wallet.entity.OrderContractAddressPair;
 import io.stormbird.wallet.entity.Ticker;
 import io.stormbird.wallet.entity.Ticket;
 import io.stormbird.wallet.entity.Token;
+import io.stormbird.wallet.entity.TokenInfo;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.repository.TokenRepositoryType;
 
@@ -38,6 +39,10 @@ public class FetchTokensInteract {
         return tokenRepository.fetchActive(wallet.address)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread());
+    }
+
+    public Observable<TokenInfo> getTokenInfo(String address) {
+        return tokenRepository.update(address);
     }
 
     private Map<String, Token> tokensToMap(Token[] tokenArray) {
@@ -107,6 +112,12 @@ public class FetchTokensInteract {
         return tokenRepository.fetchActiveTokenBalance(wallet.address, token)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread());
+    }
+
+    public Token updateDefaultBalance(Token token)
+    {
+        return tokenRepository.fetchActiveDefaultTokenBalance(token)
+                .subscribeOn(Schedulers.io()).blockingSingle();
     }
 
     public Observable<OrderContractAddressPair> updateBalancePair(Token token, MagicLinkData order)

--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
@@ -49,13 +49,6 @@ public class FetchTransactionsInteract {
                 .observeOn(AndroidSchedulers.mainThread());
     }
 
-    public Observable<Transaction[]> fetchInternalTransactions(Wallet wallet, String feemaster) {
-        return transactionRepository
-                .fetchInternalTransactionsNetwork(wallet, feemaster)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread());
-    }
-
     public Single<Transaction[]> storeTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] txList)
     {
         return transactionRepository.storeTransactions(networkInfo, wallet, txList);

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenLocalSource.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenLocalSource.java
@@ -29,4 +29,6 @@ public interface TokenLocalSource {
     Observable<List<Token>> fetchEnabledTokensSequentialList(NetworkInfo networkInfo, Wallet wallet);
     Completable saveTickers(NetworkInfo network, Wallet wallet, TokenTicker[] tokenTickers);
     Single<TokenTicker[]> fetchTickers(NetworkInfo network, Wallet wallet, Token[] tokens);
+
+    void setTokenTerminated(NetworkInfo network, Wallet wallet, Token token);
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -304,6 +304,16 @@ public class TokenRepository implements TokenRepositoryType {
                 .toObservable();
     }
 
+    @Override
+    public Observable<Token> fetchActiveDefaultTokenBalance(Token token)
+    {
+        NetworkInfo network = ethereumNetworkRepository.getDefaultNetwork();
+        return walletRepository.getDefaultWallet()
+                .flatMap(wallet -> updateBalance(network, wallet, token))
+                .observeOn(Schedulers.newThread())
+                .toObservable();
+    }
+
     private Observable<Token> fetchBalance(String walletAddress, Token token)
     {
         NetworkInfo network = ethereumNetworkRepository.getDefaultNetwork();
@@ -417,6 +427,12 @@ public class TokenRepository implements TokenRepositoryType {
     }
 
     @Override
+    public void terminateToken(Token token, Wallet wallet, NetworkInfo network)
+    {
+        localSource.setTokenTerminated(network, wallet, token);
+    }
+
+    @Override
     public Single<TokenInfo[]> update(String[] address)
     {
         return setupTokensFromLocal(address);
@@ -489,14 +505,15 @@ public class TokenRepository implements TokenRepositoryType {
      * @return
      */
     private Single<Token> updateBalance(NetworkInfo network, Wallet wallet, final Token token) {
+        if (token.isEthereum())
+        {
+            return attachEth(network, wallet);
+        }
+        else
         return Single.fromCallable(() -> {
             TokenFactory tFactory = new TokenFactory();
             try
             {
-                if (token.isEthereum())
-                {
-                    return token; //already have the balance for ETH
-                }
                 List<BigInteger> balanceArray = null;
                 List<Integer> burnArray = null;
                 BigDecimal balance = null;
@@ -757,7 +774,6 @@ public class TokenRepository implements TokenRepositoryType {
 
     public rx.Observable<TransferFromEventResponse> burnListenerObservable(String contractAddr)
     {
-        rx.Subscription sub = null;
         if (!useBackupNode)
         {
             final Event event = new Event("TransferFrom",

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
@@ -30,6 +30,7 @@ public interface TokenRepositoryType {
     Observable<Token> fetchActiveSingle(String walletAddress, Token token);
     Observable<Token> fetchCachedSingleToken(String walletAddress, String tokenAddress);
     Observable<Token> fetchActiveTokenBalance(String walletAddress, Token token);
+    Observable<Token> fetchActiveDefaultTokenBalance(Token token);
     Observable<Token[]> fetchAll(String walletAddress);
     Completable setEnable(Wallet wallet, Token token, boolean isEnabled);
     Observable<TokenInfo> update(String address);
@@ -41,4 +42,6 @@ public interface TokenRepositoryType {
     Single<Token[]> addTokens(Wallet wallet, TokenInfo[] tokenInfos);
     Single<Ticker> getEthTicker();
     Single<Token> getEthBalance(NetworkInfo network, Wallet wallet);
+
+    void terminateToken(Token token, Wallet wallet, NetworkInfo network);
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokensRealmSource.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokensRealmSource.java
@@ -578,4 +578,37 @@ public class TokensRealmSource implements TokenLocalSource {
             }
         return result;
     }
+
+    @Override
+    public void setTokenTerminated(NetworkInfo network, Wallet wallet, Token token)
+    {
+        Realm realm = null;
+        try
+        {
+            realm = realmManager.getRealmInstance(network, wallet);
+            RealmToken realmToken = realm.where(RealmToken.class)
+                    .equalTo("address", token.tokenInfo.address)
+                    .findFirst();
+
+            TransactionsRealmCache.addRealm();
+            realm.beginTransaction();
+            token.setIsTerminated(realmToken);
+            realm.commitTransaction();
+        }
+        catch (Exception ex)
+        {
+            if (realm != null && realm.isInTransaction())
+            {
+                realm.cancelTransaction();
+            }
+        }
+        finally
+        {
+            if (realm != null)
+            {
+                realm.close();
+                TransactionsRealmCache.subRealm();
+            }
+        }
+    }
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
@@ -76,12 +76,6 @@ public class TransactionRepository implements TransactionRepositoryType {
     }
 
 	@Override
-	public Observable<Transaction[]> fetchInternalTransactionsNetwork(Wallet wallet, String feemaster)
-	{
-		return blockExplorerClient.fetchContractTransactions(wallet.address, feemaster);
-	}
-
-	@Override
 	public Observable<Transaction[]> fetchNetworkTransaction(Wallet wallet, long lastBlock) {
 		NetworkInfo networkInfo = networkRepository.getDefaultNetwork();
 		return fetchFromNetwork(networkInfo, wallet, lastBlock)

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepositoryType.java
@@ -18,7 +18,6 @@ public interface TransactionRepositoryType {
 	public Observable<Transaction[]> fetchCachedTransactions(NetworkInfo network, Wallet wallet);
 	Observable<Transaction[]> fetchTransaction(Wallet wallet);
 	Observable<Transaction[]> fetchNetworkTransaction(Wallet wallet, long lastBlock);
-	Observable<Transaction[]> fetchInternalTransactionsNetwork(Wallet wallet, String feemaster);
 	Observable<TokenTransaction[]> fetchTokenTransaction(Wallet wallet, Token token);
 	Maybe<Transaction> findTransaction(Wallet wallet, String transactionHash);
 	Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password);

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionsRealmCache.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionsRealmCache.java
@@ -13,6 +13,7 @@ import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Transaction;
 import io.stormbird.wallet.entity.TransactionContract;
 import io.stormbird.wallet.entity.TransactionOperation;
+import io.stormbird.wallet.entity.TransactionType;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.repository.entity.RealmTransaction;
 import io.stormbird.wallet.repository.entity.RealmTransactionContract;
@@ -264,7 +265,7 @@ public class TransactionsRealmCache implements TransactionLocalSource {
                     realmContract.setType(ct.type);
                     realmContract.setIndices(ct.getIndicesString());
                     realmContract.setContractType(ERC875_CONTRACT_TYPE);
-                    realmContract.setOperation(ct.operation);
+                    realmContract.setOperation(ct.operation.ordinal());
                     realmContract.setOtherParty(ct.otherParty);
                     break;
                 case NORMAL_CONTRACT_TYPE:
@@ -321,7 +322,7 @@ public class TransactionsRealmCache implements TransactionLocalSource {
                     realmContract.setType(ct.type);
                     realmContract.setIndices(ct.getIndicesString());
                     realmContract.setContractType(ERC875_CONTRACT_TYPE);
-                    realmContract.setOperation(ct.operation);
+                    realmContract.setOperation(ct.operation.ordinal());
                     realmContract.setOtherParty(ct.otherParty);
                     break;
                 case NORMAL_CONTRACT_TYPE:
@@ -370,7 +371,9 @@ public class TransactionsRealmCache implements TransactionLocalSource {
                     operation.contract = new ERC875ContractTransaction();
                     ((ERC875ContractTransaction)operation.contract).balance = rawOperation.getContract().getBalance();
                     ((ERC875ContractTransaction)operation.contract).setIndicesFromString(rawOperation.getContract().getIndices());
-                    ((ERC875ContractTransaction)operation.contract).operation = rawOperation.getContract().getOperation();
+                    int operationId = rawOperation.getContract().getOperation();
+                    if (operationId >= TransactionType.ILLEGAL_VALUE.ordinal()) operationId = TransactionType.ILLEGAL_VALUE.ordinal();
+                    ((ERC875ContractTransaction)operation.contract).operation = TransactionType.values()[operationId];
                     ((ERC875ContractTransaction)operation.contract).otherParty = rawOperation.getContract().getOtherParty();
                     ((ERC875ContractTransaction)operation.contract).type = rawOperation.getContract().getType();
                     break;

--- a/app/src/main/java/io/stormbird/wallet/service/TokensService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TokensService.java
@@ -1,0 +1,78 @@
+package io.stormbird.wallet.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.stormbird.wallet.entity.Token;
+
+public class TokensService
+{
+    private Map<String, Token> tokenMap = new ConcurrentHashMap<>();
+    private List<String> terminationList = new ArrayList<>();
+
+    public TokensService() {
+
+    }
+
+    /**
+     * Add the token to the service map and return token in case we use this call in a reactive element
+     * @param t
+     * @return
+     */
+    public Token addToken(Token t)
+    {
+        tokenMap.put(t.getAddress(), t);
+        return t;
+    }
+
+    public Token getToken(String addr)
+    {
+        return tokenMap.get(addr);
+    }
+
+    public void clearTokens()
+    {
+        tokenMap.clear();
+    }
+
+    public List<Token> getAllTokens()
+    {
+        return new ArrayList<Token>(tokenMap.values());
+    }
+
+    public List<Token> getAllLiveTokens()
+    {
+        List<Token> tokens = new ArrayList<>();
+        for (Token t : tokenMap.values())
+        {
+            if (!t.isTerminated() && t.tokenInfo.name != null) tokens.add(t);
+        }
+
+        return tokens;
+    }
+
+    public void scheduleForTermination(String address)
+    {
+        if (!terminationList.contains(address)) terminationList.add(address);
+    }
+
+    public List<String> getTerminationList()
+    {
+        return terminationList;
+    }
+
+    public void clearTerminationList()
+    {
+        terminationList.clear();
+    }
+
+    public void addTokens(Token[] tokens)
+    {
+        for (Token t : tokens)
+        {
+            tokenMap.put(t.getAddress(), t);
+        }
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TransactionsNetworkClient.java
@@ -90,33 +90,6 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType 
 		}).subscribeOn(Schedulers.io());
 	}
 
-	@Override
-	public Observable<Transaction[]> fetchContractTransactions(String address, String feemaster)
-	{
-		return Observable.fromCallable(() -> {
-			List<Transaction> result = new ArrayList<>();
-			try
-			{
-				String response = readContractTransactions(address, feemaster);
-
-				Gson reader = new Gson();
-				JSONArray stateData = new JSONArray(response);
-				EtherscanTransaction[] txs = reader.fromJson(stateData.toString(), EtherscanTransaction[].class);
-				for (EtherscanTransaction etx : txs)
-				{
-					etx.internal = true;
-					result.add(etx.createTransaction());
-				}
-			}
-			catch (Exception e)
-			{
-				e.printStackTrace();
-			}
-
-			return result.toArray(new Transaction[result.size()]);
-		}).subscribeOn(Schedulers.io());
-	}
-
     private String readTransactions(NetworkInfo networkInfo, String address, String firstBlock)
     {
         okhttp3.Response response = null;

--- a/app/src/main/java/io/stormbird/wallet/service/TransactionsNetworkClientType.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TransactionsNetworkClientType.java
@@ -10,5 +10,4 @@ import io.reactivex.Observable;
 public interface TransactionsNetworkClientType {
 	Observable<Transaction[]> fetchTransactions(String forAddress);
     Observable<Transaction[]> fetchLastTransactions(NetworkInfo networkInfo, Wallet wallet, long lastBlock);
-    Observable<Transaction[]> fetchContractTransactions(String address, String feemaster);
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/TransactionsFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransactionsFragment.java
@@ -64,7 +64,6 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
 
     private SystemView systemView;
     private TransactionsAdapter adapter;
-    private HomeActivity homeActivity; //TODO: Have a central storage for tokens shared between views. Also need mutables for completion waits
     private Dialog dialog;
 
     private boolean isVisible = false;
@@ -79,7 +78,6 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         View view = inflater.inflate(R.layout.fragment_transactions, container, false);
 
         viewModel = ViewModelProviders.of(this, transactionsViewModelFactory).get(TransactionsViewModel.class);
-        homeActivity = (HomeActivity) getActivity();
 
         adapter = new TransactionsAdapter(this::onTransactionClick);
         SwipeRefreshLayout refreshLayout = view.findViewById(R.id.refresh_layout);
@@ -134,6 +132,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     public void onResume() {
         super.onResume();
         viewModel.setVisibility(isVisible);
+        viewModel.abortAndRestart(true);
         viewModel.prepare();
     }
 
@@ -167,7 +166,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     public void onDestroy()
     {
         super.onDestroy();
-        getContext().unregisterReceiver(tokenReceiver);
+        if (getContext() != null) getContext().unregisterReceiver(tokenReceiver);
     }
 
     private void onDefaultWallet(Wallet wallet)
@@ -207,7 +206,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         if (wallet == null) {
             Toast.makeText(getContext(), getString(R.string.error_wallet_not_selected), Toast.LENGTH_SHORT)
                     .show();
-        } else {
+        } else if (getContext() != null) {
             BottomSheetDialog dialog = new BottomSheetDialog(getContext());
             DepositView view = new DepositView(getContext(), wallet);
             view.setOnDepositClickListener(this::onDepositClick);
@@ -225,8 +224,9 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     public void resetTokens()
     {
         //first abort the current operation
-        viewModel.abortAndRestart(true);
+        //viewModel.abortAndRestart(true);
         adapter.clear();
+        list.setAdapter(adapter);
     }
 
     @Override

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TransactionHolder.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.ERC875ContractTransaction;
 import io.stormbird.wallet.entity.Transaction;
+import io.stormbird.wallet.entity.TransactionLookup;
 import io.stormbird.wallet.entity.TransactionOperation;
 import io.stormbird.wallet.ui.widget.OnTransactionClickListener;
 
@@ -124,12 +125,9 @@ public class TransactionHolder extends BinderViewHolder<Transaction> implements 
                 break;
         }
 
-        if (ct.operation == 0)
-        {
-            ct.operation = R.string.ticket_invalid_op;
-        }
+        String operationName = getString(TransactionLookup.typeToName(ct.operation));
 
-        type.setText(getString(ct.operation));
+        type.setText(operationName);
         address.setText(ct.name);
         value.setTextColor(ContextCompat.getColor(getContext(), colourResource));
         String ticketMove = "";
@@ -142,19 +140,19 @@ public class TransactionHolder extends BinderViewHolder<Transaction> implements 
 
         switch (ct.operation)
         {
-            case R.string.ticket_magiclink_transfer: //transfered out of our wallet via magic link (0 value)
-            case R.string.ticket_magiclink_pickup: //received ticket from a magic link
+            case MAGICLINK_TRANSFER: //transfered out of our wallet via magic link (0 value)
+            case MAGICLINK_PICKUP: //received ticket from a magic link
                 break;
-            case R.string.ticket_magiclink_sale: //we received ether from magiclink sale
+            case MAGICLINK_SALE: //we received ether from magiclink sale
                 supplimentalTxt = "+" + getScaledValue(transaction.value, ETHER_DECIMALS) + " " + ETH_SYMBOL;
                 break;
-            case R.string.ticket_magiclink_purchase: //we purchased a ticket from a magiclink
+            case MAGICLINK_PURCHASE: //we purchased a ticket from a magiclink
                 supplimentalTxt = "-" + getScaledValue(transaction.value, ETHER_DECIMALS) + " " + ETH_SYMBOL;
                 break;
-            case R.string.ticket_receive_from_magiclink:
+            case RECEIVE_FROM:
                 supplimentalTxt = "+" + getScaledValue(transaction.value, ETHER_DECIMALS) + " " + ETH_SYMBOL;
                 break;
-            case R.string.ticket_load_new_tickets:
+            case LOAD_NEW_TOKENS:
                 ticketMove = "x" + operation.value + " " + getString(R.string.tickets);
                 break;
             default:

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -216,14 +216,6 @@ public class TransactionsViewModel extends BaseViewModel
             txMap.put(tx.hash, tx);
             if (Long.valueOf(tx.blockNumber) > lastBlock) lastBlock = Long.valueOf(tx.blockNumber);
         }
-
-//        if (refreshCache)
-//        {
-//            lastBlock = 0;
-//            txArray = new Transaction[0];
-//            txMap.clear();
-//            refreshCache = false;
-//        }
     }
 
     /**

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -32,6 +32,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import io.stormbird.wallet.service.AssetDefinitionService;
+import io.stormbird.wallet.service.TokensService;
 
 public class TransactionsViewModel extends BaseViewModel
 {
@@ -44,7 +45,6 @@ public class TransactionsViewModel extends BaseViewModel
     private final MutableLiveData<Transaction[]> transactions = new MutableLiveData<>();
     private final MutableLiveData<Boolean> clearAdapter = new MutableLiveData<>();
 
-
     private final FindDefaultNetworkInteract findDefaultNetworkInteract;
     private final FindDefaultWalletInteract findDefaultWalletInteract;
     private final FetchTransactionsInteract fetchTransactionsInteract;
@@ -52,6 +52,7 @@ public class TransactionsViewModel extends BaseViewModel
     private final AddTokenInteract addTokenInteract;
     private final SetupTokensInteract setupTokensInteract;
     private final AssetDefinitionService assetDefinitionService;
+    private final TokensService tokensService;
 
     private final TransactionDetailRouter transactionDetailRouter;
     private final ExternalBrowserRouter externalBrowserRouter;
@@ -59,12 +60,15 @@ public class TransactionsViewModel extends BaseViewModel
 
     @Nullable
     private Disposable fetchTransactionDisposable;
+    @Nullable
+    private Disposable handleTerminatedContracts;
+
     private Handler handler = new Handler();
 
     private boolean isVisible = false;
     private Transaction[] txArray;
     private Map<String, Transaction> txMap = new ConcurrentHashMap<>();
-    private Map<String, Token> tokenMap = new ConcurrentHashMap<>();
+    //private Map<String, Token> tokenMap = new ConcurrentHashMap<>();
     private int transactionCount;
     private long lastBlock = 0;
     private boolean firstRun = false;
@@ -80,7 +84,8 @@ public class TransactionsViewModel extends BaseViewModel
             TransactionDetailRouter transactionDetailRouter,
             ExternalBrowserRouter externalBrowserRouter,
             HomeRouter homeRouter,
-            AssetDefinitionService assetDefinitionService) {
+            AssetDefinitionService assetDefinitionService,
+            TokensService tokensService) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.fetchTransactionsInteract = fetchTransactionsInteract;
@@ -91,6 +96,7 @@ public class TransactionsViewModel extends BaseViewModel
         this.addTokenInteract = addTokenInteract;
         this.setupTokensInteract = setupTokensInteract;
         this.assetDefinitionService = assetDefinitionService;
+        this.tokensService = tokensService;
     }
 
     @Override
@@ -289,20 +295,20 @@ public class TransactionsViewModel extends BaseViewModel
 
         //Fetch all stored tokens, but no ethd
         //TODO: after the map addTokenToChecklist stage we should be using a reduce instead of filtering in the fetch function
-        fetchTransactionDisposable = fetchTokensInteract
-                .fetchSequentialNoEth(wallet.getValue())
+        fetchTransactionDisposable = Observable.fromCallable(tokensService::getAllTokens)
+                .flatMapIterable(token -> token)
+                .filter(token -> !token.isEthereum())
                 .map(this::addTokenToChecklist)
-                .flatMap(token -> fetchTransactionsInteract.fetch(new Wallet(token.tokenInfo.address), token)) //single that fetches all the tx's from etherscan for each token from fetchSequential
-                .flatMap(tokenTransactions -> setupTokensInteract.processTokenTransactions(defaultWallet().getValue(), tokenTransactions)) //process these into a map
-                .flatMap(transactions -> fetchTransactionsInteract.storeTransactionsObservable(network.getValue(), wallet.getValue(), transactions))
-                .flatMap(this::removeFromMap)
+                .map(token -> fetchTransactionsInteract.fetch(new Wallet(token.tokenInfo.address), token)) //single that fetches all the tx's from etherscan for each token from fetchSequential
+                .map(tokenTransactions -> setupTokensInteract.processTokenTransactions(defaultWallet().getValue(), tokenTransactions.blockingLast())) //process these into a map
+                .map(transactions -> fetchTransactionsInteract.storeTransactionsObservable(network.getValue(), wallet.getValue(), transactions.blockingLast()))
+                .map(transactions -> removeFromMapTx(transactions.blockingLast()))
                 .subscribeOn(Schedulers.newThread())
                 .subscribe(this::updateDisplay, this::onError, this::siftUnknownTransactions);
     }
 
     private Token addTokenToChecklist(Token token)
     {
-        tokenMap.put(token.getAddress(), token);
         setupTokensInteract.addTokenToMap(token);
         return token;
     }
@@ -312,17 +318,19 @@ public class TransactionsViewModel extends BaseViewModel
     private void siftUnknownTransactions()
     {
         //add in the XML contract address to list of unknowns to fetch if we don't have it already
-        setupTokensInteract.setupUnknownList(tokenMap, assetDefinitionService.getAllContracts(network.getValue().chainId));
+        setupTokensInteract.setupUnknownList(tokensService, assetDefinitionService.getAllContracts(network.getValue().chainId));
 
-        fetchTransactionDisposable = setupTokensInteract.processRemainingTransactions(txMap.values().toArray(new Transaction[0]), tokenMap) //patches tx's and returns unknown contracts
+        fetchTransactionDisposable = setupTokensInteract.processRemainingTransactions(txMap.values().toArray(new Transaction[0]), tokensService) //patches tx's and returns unknown contracts
                 .flatMap(transactions -> fetchTransactionsInteract.storeTransactions(network.getValue(), wallet.getValue(), transactions).toObservable()) //store patched TX
                 .map(setupTokensInteract::getUnknownContracts) //emit a list of string addresses
                 .flatMapIterable(address -> address) //change to a sequential stream
-                .flatMap(setupTokensInteract::addToken) //fetch token info
-                .flatMap(addTokenInteract::add) //add to cached tokens
+                .map(address -> setupTokensInteract.addToken(address).blockingLast()) //fetch token info
+                .filter(tokenInfo -> tokenInfo.name != null)
+                .map(tokenInfo -> addTokenInteract.add(tokenInfo).blockingLast()) //add to cached tokens
+                .map(tokensService::addToken)
                 .flatMap(token -> setupTokensInteract.reProcessTokens(token, txMap)) //run through transactions now we have the new token
                 .flatMap(this::removeFromMap) //remove the handled transactions from the map (so we don't need to scan these transactions again)
-                .flatMap(transactions -> fetchTransactionsInteract.storeTransactions(network.getValue(), wallet.getValue(), transactions).toObservable()) //store newly fixed up transactions
+                .map(transactions -> fetchTransactionsInteract.storeTransactions(network.getValue(), wallet.getValue(), transactions).blockingGet()) //store newly fixed up transactions
                 .subscribeOn(Schedulers.io())
                 .subscribe(this::updateDisplay, this::onError, this::storeUnprocessedTx); //update the screen with any updated transactions
 
@@ -349,22 +357,26 @@ public class TransactionsViewModel extends BaseViewModel
         Transaction[] transactions = txMap.values().toArray(new Transaction[txMap.size()]);
         fetchTransactionDisposable = fetchTransactionsInteract.storeTransactions(network.getValue(), wallet.getValue(), transactions).toObservable()
                 .subscribeOn(Schedulers.io())
-                .subscribe(this::completeCycle, this::onError);
+                .subscribe(this::completeCycle, this::onError, this::scanForTerminatedTokens);
     }
 
     private void completeCycle(Transaction[] transactions)
     {
         progress.postValue(false); //ensure spinner is off on completion (in case user forced update)
-        fetchTransactionDisposable = null;
-        if (firstRun)
+    }
+
+    private Transaction[] removeFromMapTx(Transaction[] transactions)
+    {
+        Log.d(TAG, "GOT: " + transactions.length );
+        //first remove all these transactions from the network + cached list
+        for (Transaction t : transactions)
         {
-            firstRun = false;
-            clearAdapter.postValue(true);
+            txMap.remove(t.hash);
         }
-        else
-        {
-            checkIfRegularUpdateNeeded();
-        }
+
+        Log.d(TAG, "Remaining unknown: " + txMap.size() );
+        transactionCount += transactions.length;
+        return transactions;
     }
 
     private Observable<Transaction[]> removeFromMap(Transaction[] transactions)
@@ -471,8 +483,31 @@ public class TransactionsViewModel extends BaseViewModel
         isVisible = visibility;
     }
 
-    public void clearTransactionEntries()
+    private void scanForTerminatedTokens()
     {
+        checkIfRegularUpdateNeeded();
 
+        //run through the map and see if there were any tokens that have been terminated
+        handleTerminatedContracts = Observable.fromCallable(tokensService::getTerminationList)
+                .flatMapIterable(address -> address)
+                .map(address -> setupTokensInteract.terminateToken(tokensService.getToken(address), defaultWallet().getValue(), defaultNetwork().getValue()))
+                .subscribeOn(Schedulers.newThread())
+                .subscribe(this::onTokenForTermination, this::onScanError, this::wipeTerminationList);
+    }
+
+    private void onScanError(Throwable throwable)
+    {
+        handleTerminatedContracts.dispose();
+    }
+
+    private void wipeTerminationList()
+    {
+        handleTerminatedContracts.dispose();
+        tokensService.clearTerminationList();
+    }
+
+    private void onTokenForTermination(Token token)
+    {
+        System.out.print("Terminated: " + token.getAddress());
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -3,8 +3,10 @@ package io.stormbird.wallet.viewmodel;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Handler;
+import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.text.format.DateUtils;
 import android.util.Log;
@@ -14,9 +16,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.stormbird.wallet.entity.ERC875ContractTransaction;
 import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.Transaction;
+import io.stormbird.wallet.entity.TransactionContract;
+import io.stormbird.wallet.entity.TransactionType;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.interact.AddTokenInteract;
 import io.stormbird.wallet.interact.FetchTokensInteract;
@@ -33,6 +38,9 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.service.TokensService;
+
+import static io.stormbird.wallet.entity.TransactionDecoder.buildMethodId;
+import static io.stormbird.wallet.entity.TransactionDecoder.isEndContract;
 
 public class TransactionsViewModel extends BaseViewModel
 {
@@ -68,11 +76,9 @@ public class TransactionsViewModel extends BaseViewModel
     private boolean isVisible = false;
     private Transaction[] txArray;
     private Map<String, Transaction> txMap = new ConcurrentHashMap<>();
-    //private Map<String, Token> tokenMap = new ConcurrentHashMap<>();
     private int transactionCount;
     private long lastBlock = 0;
-    private boolean firstRun = false;
-    private boolean refreshCache = false;
+    private boolean restoreRequired = false;
 
     TransactionsViewModel(
             FindDefaultNetworkInteract findDefaultNetworkInteract,
@@ -115,7 +121,6 @@ public class TransactionsViewModel extends BaseViewModel
 
     public void abortAndRestart(boolean refreshCache)
     {
-        firstRun = false;
         handler.removeCallbacks(startFetchTransactionsTask);
         if (fetchTransactionDisposable != null && !fetchTransactionDisposable.isDisposed())
         {
@@ -127,9 +132,9 @@ public class TransactionsViewModel extends BaseViewModel
         txArray = null;
         txMap.clear();
         setupTokensInteract.clearAll();
-        this.refreshCache = refreshCache;
+        //this.refreshCache = refreshCache;
 
-        prepare();
+        //prepare();
     }
 
     public LiveData<NetworkInfo> defaultNetwork() {
@@ -148,7 +153,6 @@ public class TransactionsViewModel extends BaseViewModel
 
     public void prepare()
     {
-        firstRun = false;
         progress.postValue(true);
         disposable = findDefaultNetworkInteract
                 .find()
@@ -172,6 +176,7 @@ public class TransactionsViewModel extends BaseViewModel
 
                 fetchTransactionDisposable =
                         fetchTransactionsInteract.fetchCached(network.getValue(), wallet.getValue())
+                                .flatMap(this::checkForContractTerminator)
                                 .subscribeOn(Schedulers.io())
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .subscribe(this::onTransactions, this::onError, this::fetchNetworkTransactions);
@@ -212,13 +217,13 @@ public class TransactionsViewModel extends BaseViewModel
             if (Long.valueOf(tx.blockNumber) > lastBlock) lastBlock = Long.valueOf(tx.blockNumber);
         }
 
-        if (refreshCache)
-        {
-            lastBlock = 0;
-            txArray = new Transaction[0];
-            txMap.clear();
-            refreshCache = false;
-        }
+//        if (refreshCache)
+//        {
+//            lastBlock = 0;
+//            txArray = new Transaction[0];
+//            txMap.clear();
+//            refreshCache = false;
+//        }
     }
 
     /**
@@ -227,7 +232,17 @@ public class TransactionsViewModel extends BaseViewModel
      */
     private void fetchNetworkTransactions()
     {
-        updateDisplay(txArray);
+        if (restoreRequired)
+        {
+            lastBlock = 0;
+            txArray = new Transaction[0];
+            txMap.clear();
+            restoreRequired = false;
+        }
+        else
+        {
+            updateDisplay(txArray);
+        }
 
         Log.d(TAG, "Fetching network transactions.");
         //now fetch new transactions on main account
@@ -281,12 +296,6 @@ public class TransactionsViewModel extends BaseViewModel
      */
     private void enumerateTokens()
     {
-        //check transaction difference - this is a first run if we have network transactions but no cached transactions
-        if (txArray.length == 0 && txMap.size() > 0)
-        {
-            firstRun = true;
-        }
-
         //stop the spinner
         progress.postValue(false);
         Log.d(TAG, "Enumerating tokens");
@@ -298,9 +307,10 @@ public class TransactionsViewModel extends BaseViewModel
         fetchTransactionDisposable = Observable.fromCallable(tokensService::getAllTokens)
                 .flatMapIterable(token -> token)
                 .filter(token -> !token.isEthereum())
+                .filter(token -> !token.isTerminated())
                 .map(this::addTokenToChecklist)
                 .map(token -> fetchTransactionsInteract.fetch(new Wallet(token.tokenInfo.address), token)) //single that fetches all the tx's from etherscan for each token from fetchSequential
-                .map(tokenTransactions -> setupTokensInteract.processTokenTransactions(defaultWallet().getValue(), tokenTransactions.blockingLast())) //process these into a map
+                .map(tokenTransactions -> setupTokensInteract.processTokenTransactions(defaultWallet().getValue(), tokenTransactions.blockingLast(), tokensService)) //process these into a map
                 .map(transactions -> fetchTransactionsInteract.storeTransactionsObservable(network.getValue(), wallet.getValue(), transactions.blockingLast()))
                 .map(transactions -> removeFromMapTx(transactions.blockingLast()))
                 .subscribeOn(Schedulers.newThread())
@@ -328,7 +338,7 @@ public class TransactionsViewModel extends BaseViewModel
                 .filter(tokenInfo -> tokenInfo.name != null)
                 .map(tokenInfo -> addTokenInteract.add(tokenInfo).blockingLast()) //add to cached tokens
                 .map(tokensService::addToken)
-                .flatMap(token -> setupTokensInteract.reProcessTokens(token, txMap)) //run through transactions now we have the new token
+                .flatMap(token -> setupTokensInteract.reProcessTokens(token, txMap, tokensService)) //run through transactions now we have the new token
                 .flatMap(this::removeFromMap) //remove the handled transactions from the map (so we don't need to scan these transactions again)
                 .map(transactions -> fetchTransactionsInteract.storeTransactions(network.getValue(), wallet.getValue(), transactions).blockingGet()) //store newly fixed up transactions
                 .subscribeOn(Schedulers.io())
@@ -485,6 +495,7 @@ public class TransactionsViewModel extends BaseViewModel
 
     private void scanForTerminatedTokens()
     {
+        fetchTransactionDisposable = null;
         checkIfRegularUpdateNeeded();
 
         //run through the map and see if there were any tokens that have been terminated
@@ -509,5 +520,49 @@ public class TransactionsViewModel extends BaseViewModel
     private void onTokenForTermination(Token token)
     {
         System.out.print("Terminated: " + token.getAddress());
+    }
+
+    /**
+     * Detect any termination function. If we see one of these there's no need to do any further checking for this token
+     * @param transactions
+     * @return
+     */
+    private Observable<Transaction[]> checkForContractTerminator(Transaction[] transactions)
+    {
+        return Observable.fromCallable(() -> {
+            for (Transaction tx : transactions)
+            {
+                if (tx != null)
+                {
+                    if (checkForIllegalType(tx)) break;
+                    if (tx.input != null && tx.input.length() == 10)
+                    {
+                        Token t = tokensService.getToken(tx.to);
+                        if (t != null && !t.isTerminated()
+                                && isEndContract(tx.input))
+                        {
+                            //write to database this contract is terminated
+                            setupTokensInteract.terminateToken(tokensService.getToken(t.getAddress()),
+                                                               defaultWallet().getValue(), defaultNetwork().getValue());
+                        }
+                    }
+                }
+            }
+            return transactions;
+        });
+    }
+
+    private boolean checkForIllegalType(Transaction tx)
+    {
+        if (tx.operations != null && tx.operations.length > 0 && tx.operations[0] != null)
+        {
+            TransactionContract ct = tx.operations[0].contract;
+            if (ct instanceof ERC875ContractTransaction && ((ERC875ContractTransaction)ct).operation == TransactionType.ILLEGAL_VALUE)
+            {
+                restoreRequired = true;
+            }
+        }
+
+        return restoreRequired;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModelFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModelFactory.java
@@ -21,6 +21,7 @@ import io.stormbird.wallet.router.SettingsRouter;
 import io.stormbird.wallet.router.TransactionDetailRouter;
 import io.stormbird.wallet.router.WalletRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
+import io.stormbird.wallet.service.TokensService;
 
 public class TransactionsViewModelFactory implements ViewModelProvider.Factory {
 
@@ -34,6 +35,7 @@ public class TransactionsViewModelFactory implements ViewModelProvider.Factory {
     private final ExternalBrowserRouter externalBrowserRouter;
     private final HomeRouter homeRouter;
     private final AssetDefinitionService assetDefinitionService;
+    private final TokensService tokensService;
 
     public TransactionsViewModelFactory(
             FindDefaultNetworkInteract findDefaultNetworkInteract,
@@ -45,7 +47,8 @@ public class TransactionsViewModelFactory implements ViewModelProvider.Factory {
             TransactionDetailRouter transactionDetailRouter,
             ExternalBrowserRouter externalBrowserRouter,
             HomeRouter homeRouter,
-            AssetDefinitionService assetDefinitionService) {
+            AssetDefinitionService assetDefinitionService,
+            TokensService tokensService) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.fetchTransactionsInteract = fetchTransactionsInteract;
@@ -56,6 +59,7 @@ public class TransactionsViewModelFactory implements ViewModelProvider.Factory {
         this.addTokenInteract = addTokenInteract;
         this.setupTokensInteract = setupTokensInteract;
         this.assetDefinitionService = assetDefinitionService;
+        this.tokensService = tokensService;
     }
 
     @NonNull
@@ -71,6 +75,7 @@ public class TransactionsViewModelFactory implements ViewModelProvider.Factory {
                 transactionDetailRouter,
                 externalBrowserRouter,
                 homeRouter,
-                assetDefinitionService);
+                assetDefinitionService,
+                tokensService);
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModelFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModelFactory.java
@@ -16,6 +16,7 @@ import io.stormbird.wallet.router.AssetDisplayRouter;
 import io.stormbird.wallet.router.ChangeTokenCollectionRouter;
 import io.stormbird.wallet.router.SendTokenRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
+import io.stormbird.wallet.service.TokensService;
 
 public class WalletViewModelFactory implements ViewModelProvider.Factory {
     private final FetchTokensInteract fetchTokensInteract;
@@ -29,6 +30,7 @@ public class WalletViewModelFactory implements ViewModelProvider.Factory {
     private final AddTokenInteract addTokenInteract;
     private final SetupTokensInteract setupTokensInteract;
     private final AssetDefinitionService assetDefinitionService;
+    private final TokensService tokensService;
 
     public WalletViewModelFactory(/*FindDefaultNetworkInteract findDefaultNetworkInteract,*/
                                   FetchTokensInteract fetchTokensInteract,
@@ -41,7 +43,8 @@ public class WalletViewModelFactory implements ViewModelProvider.Factory {
                                   GetDefaultWalletBalance getDefaultWalletBalance,
                                   AddTokenInteract addTokenInteract,
                                   SetupTokensInteract setupTokensInteract,
-                                  AssetDefinitionService assetDefinitionService) {
+                                  AssetDefinitionService assetDefinitionService,
+                                  TokensService tokensService) {
         //this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.fetchTokensInteract = fetchTokensInteract;
         this.addTokenRouter = addTokenRouter;
@@ -54,6 +57,7 @@ public class WalletViewModelFactory implements ViewModelProvider.Factory {
         this.addTokenInteract = addTokenInteract;
         this.setupTokensInteract = setupTokensInteract;
         this.assetDefinitionService = assetDefinitionService;
+        this.tokensService = tokensService;
 
     }
 
@@ -72,6 +76,7 @@ public class WalletViewModelFactory implements ViewModelProvider.Factory {
                 getDefaultWalletBalance,
                 addTokenInteract,
                 setupTokensInteract,
-                assetDefinitionService);
+                assetDefinitionService,
+                tokensService);
     }
 }

--- a/app/src/test/java/io/stormbird/wallet/MarketOrderTest.java
+++ b/app/src/test/java/io/stormbird/wallet/MarketOrderTest.java
@@ -124,13 +124,6 @@ public class MarketOrderTest
                 return null;
             }
 
-
-            @Override
-            public Observable<Transaction[]> fetchInternalTransactionsNetwork(Wallet wallet, String feemaster)
-            {
-                return null;
-            }
-
             @Override
             public Observable<TokenTransaction[]> fetchTokenTransaction(Wallet wallet, Token token) {
                 return null;

--- a/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
+++ b/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
@@ -80,13 +80,6 @@ public class QRSelectionTest
                 return null;
             }
 
-
-            @Override
-            public Observable<Transaction[]> fetchInternalTransactionsNetwork(Wallet wallet, String feemaster)
-            {
-                return null;
-            }
-
             @Override
             public Observable<TokenTransaction[]> fetchTokenTransaction(Wallet wallet, Token token) {
                 return null;


### PR DESCRIPTION
This PR builds on the previous 'Consolidated Token Service' upgrade now we can coordinate between the wallet and transaction views. Now we detect dead contracts from the transaction fetch, mark them as thus and don't try to query them again.

This reduces a lot of network traffic.